### PR TITLE
Add data-name form tag attribute allowing cf7 back-end validation.

### DIFF
--- a/tags/1.5.7/includes/form-tag.php
+++ b/tags/1.5.7/includes/form-tag.php
@@ -87,7 +87,7 @@ function wpcf7_intl_tel_formtag_handler ( $tag ){
 	$atts_country_iso= wpcf7_format_atts( $atts_country_iso);
 
 	$html = sprintf(
-		'<span class="wpcf7-form-control-wrap %1$s"><input %2$s /><input %3$s /><input %5$s /><input %6$s /><input %7$s />%4$s</span>',
+		'<span class="wpcf7-form-control-wrap %1$s" data-name="%1$s"><input %2$s /><input %3$s /><input %5$s /><input %6$s /><input %7$s />%4$s</span>',
 		sanitize_html_class( $tag->name ), $atts, $atts_hidden, $validation_error, $atts_country, $atts_country_code, $atts_country_iso );
 
 	return $html;


### PR DESCRIPTION
Without data-name tag in the latest cf7 versions back-end form validation is skipped.